### PR TITLE
normalized VDV AKS74 ammunition

### DIFF
--- a/GameData/Generated/Gameplay/Gfx/Ammunition.ndf
+++ b/GameData/Generated/Gameplay/Gfx/Ammunition.ndf
@@ -20242,7 +20242,7 @@ Ammo_FM_AKS_74 is TAmmunitionDescriptor
     CanShootOnPosition                = True
     CanShootWhileMoving               = True
     NbrProjectilesSimultanes          = 1
-    AffichageMunitionParSalve         = 3
+    AffichageMunitionParSalve         = 12
     MissileDescriptor                 = nil
     InterfaceWeaponTexture            = "Texture_Interface_Weapon_AK74"
     SmokeDescriptor                   = nil


### PR DESCRIPTION
Changed AffichageMunitionParSalve to 12 for the AKS74 as seen in other variants (AK74).